### PR TITLE
Add support for redis host/port from URL

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -41,7 +41,13 @@ locally or to where you wish to install Federated Wiki.*
 is done by adding the following configuration setting
 
 ```
---database '{"type": "wiki-storage-redis" "host": "...", "port": nnn, "options": {...}}'
+--database '{"type": "redis", "host": "...", "port": nnn, "options": {...}}'
+```
+
+The host and port will also optionally be read from the environment variable named in the configuration field "env_url", or from a URL in the field "url" - this is to ease heroku-style deployment, e.g.
+
+```
+--database '{"type": "redis", "env_url": "REDISCLOUD_URL", "options": {...}}'
 ```
 
 ## Developer Notes

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -1,6 +1,7 @@
 var redis = require('redis')
   , fsPage = require('wiki-server/lib/page')
   , synopsis = require('wiki-client/lib/synopsis')
+  , url = require('url')
 
 
 module.exports = function (opts) {
@@ -8,10 +9,20 @@ module.exports = function (opts) {
   var database = opts.database
     , port = database.port
     , host = database.host
-    , options = database.options
-    , client = redis.createClient(port, host, options)
-    , classicPageGet = fsPage(opts).get
+    , options = database.options || {}
 
+  var database_url = database.url || process.env[database.env_url]
+  if (database_url) {
+    var parts = url.parse(database_url)
+    port = parts.port
+    host = parts.hostname
+    if (parts.auth) {
+      options.auth_pass = parts.auth.split(":")[1]
+    }
+  }
+
+  var client = redis.createClient(port, host, options)
+    , classicPageGet = fsPage(opts).get
 
   if (options && options.database) {
     client.select(options.database);


### PR DESCRIPTION
Allows configuration of redis connection information (including password) from a parsed URL, either directly or from a named environment variable.

(I can submit a similar small change for wiki-storage-mongodb to take a named environment variable rather than the hard-coded choices currently checked there, if this is acceptable.)
